### PR TITLE
Specify export NODE_IP is external IP

### DIFF
--- a/install_guide_myNode.md
+++ b/install_guide_myNode.md
@@ -86,7 +86,7 @@ Save and exit:
 `Enter`
 
 To connect to your app:
-(replace x.x.x.x with your IP)
+(replace x.x.x.x with your IP - NOTE: This is your external IP)
 ```sh 
 $ cd
 $ cd sphinx-relay/config/


### PR DESCRIPTION
update the doco to specific that the IP address in export NODE_IP  is your external IP

I think it would be a good idea to have NODE_IP and NODE_PORT as line items in the app.json or config.json files