### PR TITLE
Add updates for Voltage Integration

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -22,7 +22,8 @@ const port = process.env.PORT || config.node_http_port || 3001
 console.log("=> env:", env)
 // console.log('=> config: ',config)
 
-process.env.GRPC_SSL_CIPHER_SUITES = 'HIGH+ECDSA'
+process.env.GRPC_SSL_CIPHER_SUITES = 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384';
+process.env.NODE_EXTRA_CA_CERTS = config.tls_location;
 
 // START SETUP!
 async function start() {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -36,8 +36,6 @@ export async function unlocker(req, res): Promise<boolean> {
       return false
     }
 
-    console.log("PWD", password, typeof password)
-    console.log("ENCMAC", encMac, typeof encMac)
     const decMac = decryptMacaroon(password, encMac)
     if (!decMac) {
       failure(res, 'failed to decrypt macaroon')


### PR DESCRIPTION
Couple things that are needed to work with Voltage nodes. We need to support more cipher suites for TLS certificates and also explicitly add in the configured LND certificate into Node's CA pool.

I also removed the console.logs that logged the password and encrypted macaroon data. I don't think those should probably be kept in logs.

Thanks!