### PR TITLE
Fixing docker build error messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN apt-get update
 
 RUN apt install -y make python-minimal
 RUN apt install -y g++ gcc libmcrypt-dev
+RUN apt-get -y install git
+
+RUN rm ./package-lock.json
 
 RUN npm install bcrypt
 RUN npm install


### PR DESCRIPTION
added these two lines because we were getting an error message of ERR! enoent undefined ls-remote -h -t https://github.com/tierion/js-macaroon.git which meant that our git binary was not there so I added apt-get git and then also an npm error which complained about the package.json not being available and it seemed our own package-lock.json was interfering with that.

 

- [ ] Test it on your own machine before merging into master please