### PR TITLE
Removing Lighting from default logs

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -33,7 +33,7 @@ export function loadConfig() {
     lightning_provider: provider,
     logging:
       logg ||
-      'LIGHTNING,TRIBES,MEME,NOTIFICATION,EXPRESS,NETWORK,DB,PROXY,LSAT',
+      'TRIBES,MEME,NOTIFICATION,EXPRESS,NETWORK,DB,PROXY,LSAT',
     senza_url: ENV.SENZA_URL || config.senza_url,
     macaroon_location: ENV.MACAROON_LOCATION || config.macaroon_location,
     router_macaroon_location:


### PR DESCRIPTION
Removing the LIGHTING from the default log options since it seems like it logs a bunch and is spamming the logs and not providing too much useful info.

Still able to add it back by manually selecting what you want in the logging config but don't want here for the default option

let me know if this looks good or if we want to keep it there for whatever reason