### PR TITLE
Updated the generate token function

### DIFF
--- a/src/controllers/contacts.ts
+++ b/src/controllers/contacts.ts
@@ -232,13 +232,7 @@ export const generateToken = async (req, res) => {
     if (isProxy()) {
       tribes.subscribe(`${pubkey}/#`, network.receiveMqttMessage) // add MQTT subsription
     }
-    //  create transport token and send back to client
-    // save private key and send public key
     owner.update({ authToken: hash })
-    // Send transport pubkey
-    success(res, {
-      id: (owner && owner.id) || 0,
-    })
   }
 
   success(res, {


### PR DESCRIPTION
Removed this bit of code because it was causing an error `ERR_HTTP_HEADERS_SENT` because we try to send back two responses