### PR TITLE
Adding to this workflow to tag a latest build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -54,3 +54,11 @@ jobs:
           --platform linux/amd64,linux/arm64,linux/arm/v7 \
           --tag "${{ secrets.DOCKER_HUB_USER }}/sphinx-relay:${{ env.RELEASE_TAG }}" \
           --output "type=registry" ./
+      - name: Run Docker buildx with latest tag
+        run: |
+          docker buildx build \
+          --cache-from "type=local,src=/tmp/.buildx-cache" \
+          --cache-to "type=local,dest=/tmp/.buildx-cache" \
+          --platform linux/amd64,linux/arm64,linux/arm/v7 \
+          --tag "${{ secrets.DOCKER_HUB_USER }}/sphinx-relay:latest" \
+          --output "type=registry" ./

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Build Relay
       working-directory: ./relay
       run: |
-        npm install && npm run build && docker build -t sphinxlightning/sphinx-relay-test . 
+        npm install && npm run build && docker build -t sphinxlightning/sphinx-relay . 
     - name: Checkout stack
       run: |
         git clone https://github.com/stakwork/sphinx-stack.git stack


### PR DESCRIPTION
** Note ** I havent tested this to see if it works but it seems like a pretty simple change to get the latest tag on docker for relay instead of only having version tags