### PR TITLE
automatically update proto files

### DIFF
--- a/.github/workflows/update_proto.yml
+++ b/.github/workflows/update_proto.yml
@@ -1,0 +1,26 @@
+name: Update proto files
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+
+jobs:
+  update_proto:
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: checkout LND
+        uses: actions/checkout@v3
+        with:
+          repository: lightningnetwork/lnd
+          path: lnd
+      - name: update proto files
+        run: |
+          find lnd/lnrpc -name '*.proto' -exec bash -c 'test -e proto/`basename {}` && cp {} proto' \;
+          sed -i 's/^import.*\//import "/' proto/*
+          git config user.name Github Actions
+          git config user.email github-actions@github.com
+          git add proto
+          git commit -m "Update proto files" || echo -n
+          git push

--- a/proto/lightning.proto
+++ b/proto/lightning.proto
@@ -58,7 +58,7 @@ service Lightning {
     /* lncli: `sendcoins`
     SendCoins executes a request to send coins to a particular address. Unlike
     SendMany, this RPC call only allows creating a single output at a time. If
-    neither target_conf, or sat_per_byte are set, then the internal wallet will
+    neither target_conf, or sat_per_vbyte are set, then the internal wallet will
     consult its fee model to determine a fee for the default confirmation
     target.
     */
@@ -82,7 +82,7 @@ service Lightning {
 
     /* lncli: `sendmany`
     SendMany handles a request for a transaction that creates multiple specified
-    outputs in parallel. If neither target_conf, or sat_per_byte are set, then
+    outputs in parallel. If neither target_conf, or sat_per_vbyte are set, then
     the internal wallet will consult its fee model to determine a fee for the
     default confirmation target.
     */
@@ -199,6 +199,16 @@ service Lightning {
     then be used to manually progress the channel funding flow.
     */
     rpc OpenChannel (OpenChannelRequest) returns (stream OpenStatusUpdate);
+
+    /* lncli: `batchopenchannel`
+    BatchOpenChannel attempts to open multiple single-funded channels in a
+    single transaction in an atomic way. This means either all channel open
+    requests succeed at once or all attempts are aborted if any of them fail.
+    This is the safer variant of using PSBTs to manually fund a batch of
+    channels through the OpenChannel RPC.
+    */
+    rpc BatchOpenChannel (BatchOpenChannelRequest)
+        returns (BatchOpenChannelResponse);
 
     /*
     FundingStateStep is an advanced funding related call that allows the caller
@@ -330,7 +340,14 @@ service Lightning {
     rpc ListPayments (ListPaymentsRequest) returns (ListPaymentsResponse);
 
     /*
-    DeleteAllPayments deletes all outgoing payments from DB.
+    DeletePayment deletes an outgoing payment from DB. Note that it will not
+    attempt to delete an In-Flight payment, since that would be unsafe.
+    */
+    rpc DeletePayment (DeletePaymentRequest) returns (DeletePaymentResponse);
+
+    /*
+    DeleteAllPayments deletes all outgoing payments from DB. Note that it will
+    not attempt to delete In-Flight payments, since that would be unsafe.
     */
     rpc DeleteAllPayments (DeleteAllPaymentsRequest)
         returns (DeleteAllPaymentsResponse);
@@ -426,8 +443,9 @@ service Lightning {
     /* lncli: `fwdinghistory`
     ForwardingHistory allows the caller to query the htlcswitch for a record of
     all HTLCs forwarded within the target time range, and integer offset
-    within that time range. If no time-range is specified, then the first chunk
-    of the past 24 hrs of forwarding history are returned.
+    within that time range, for a maximum number of events. If no maximum number
+    of events is specified, up to 100 events will be returned. If no time-range
+    is specified, then events will be returned in the order that they occured.
 
     A list of forwarding events are returned. The size of each forwarding event
     is 40 bytes, and the max message size able to be returned in gRPC is 4 MiB.
@@ -514,6 +532,72 @@ service Lightning {
     */
     rpc ListPermissions (ListPermissionsRequest)
         returns (ListPermissionsResponse);
+
+    /*
+    CheckMacaroonPermissions checks whether a request follows the constraints
+    imposed on the macaroon and that the macaroon is authorized to follow the
+    provided permissions.
+    */
+    rpc CheckMacaroonPermissions (CheckMacPermRequest)
+        returns (CheckMacPermResponse);
+
+    /*
+    RegisterRPCMiddleware adds a new gRPC middleware to the interceptor chain. A
+    gRPC middleware is software component external to lnd that aims to add
+    additional business logic to lnd by observing/intercepting/validating
+    incoming gRPC client requests and (if needed) replacing/overwriting outgoing
+    messages before they're sent to the client. When registering the middleware
+    must identify itself and indicate what custom macaroon caveats it wants to
+    be responsible for. Only requests that contain a macaroon with that specific
+    custom caveat are then sent to the middleware for inspection. The other
+    option is to register for the read-only mode in which all requests/responses
+    are forwarded for interception to the middleware but the middleware is not
+    allowed to modify any responses. As a security measure, _no_ middleware can
+    modify responses for requests made with _unencumbered_ macaroons!
+    */
+    rpc RegisterRPCMiddleware (stream RPCMiddlewareResponse)
+        returns (stream RPCMiddlewareRequest);
+
+    /* lncli: `sendcustom`
+    SendCustomMessage sends a custom peer message.
+    */
+    rpc SendCustomMessage (SendCustomMessageRequest)
+        returns (SendCustomMessageResponse);
+
+    /* lncli: `subscribecustom`
+    SubscribeCustomMessages subscribes to a stream of incoming custom peer
+    messages.
+    */
+    rpc SubscribeCustomMessages (SubscribeCustomMessagesRequest)
+        returns (stream CustomMessage);
+}
+
+message SubscribeCustomMessagesRequest {
+}
+
+message CustomMessage {
+    // Peer from which the message originates
+    bytes peer = 1;
+
+    // Message type. This value will be in the custom range (>= 32768).
+    uint32 type = 2;
+
+    // Raw message data
+    bytes data = 3;
+}
+
+message SendCustomMessageRequest {
+    // Peer to send the message to
+    bytes peer = 1;
+
+    // Message type. This value needs to be in the custom range (>= 32768).
+    uint32 type = 2;
+
+    // Raw message data.
+    bytes data = 3;
+}
+
+message SendCustomMessageResponse {
 }
 
 message Utxo {
@@ -582,6 +666,9 @@ message GetTransactionsRequest {
     default to this option.
     */
     int32 end_height = 2;
+
+    // An optional filter to only include transactions relevant to an account.
+    string account = 3;
 }
 
 message TransactionDetails {
@@ -666,7 +753,8 @@ message SendRequest {
     The maximum number of satoshis that will be paid as a fee of the payment.
     This value can be represented either as a percentage of the amount being
     sent, or as a fixed amount of the maximum fee the user is willing the pay to
-    send the payment.
+    send the payment. If not specified, lnd will use a default value of 100%
+    fees for small amounts (<=1k sat) or 5% fees for larger amounts.
     */
     FeeLimit fee_limit = 8;
 
@@ -708,6 +796,11 @@ message SendRequest {
     fallback.
     */
     repeated FeatureBit dest_features = 15;
+
+    /*
+    The payment address of the generated invoice.
+    */
+    bytes payment_addr = 16;
 }
 
 message SendResponse {
@@ -783,6 +876,9 @@ message ChannelAcceptRequest {
     // A bit-field which the initiator uses to specify proposed channel
     // behavior.
     uint32 channel_flags = 13;
+
+    // The commitment type the initiator wishes to use for the proposed channel.
+    CommitmentType commitment_type = 14;
 }
 
 message ChannelAcceptResponse {
@@ -791,6 +887,58 @@ message ChannelAcceptResponse {
 
     // The pending channel id to which this response applies.
     bytes pending_chan_id = 2;
+
+    /*
+    An optional error to send the initiating party to indicate why the channel
+    was rejected. This field *should not* contain sensitive information, it will
+    be sent to the initiating party. This field should only be set if accept is
+    false, the channel will be rejected if an error is set with accept=true
+    because the meaning of this response is ambiguous. Limited to 500
+    characters.
+    */
+    string error = 3;
+
+    /*
+    The upfront shutdown address to use if the initiating peer supports option
+    upfront shutdown script (see ListPeers for the features supported). Note
+    that the channel open will fail if this value is set for a peer that does
+    not support this feature bit.
+    */
+    string upfront_shutdown = 4;
+
+    /*
+    The csv delay (in blocks) that we require for the remote party.
+    */
+    uint32 csv_delay = 5;
+
+    /*
+    The reserve amount in satoshis that we require the remote peer to adhere to.
+    We require that the remote peer always have some reserve amount allocated to
+    them so that there is always a disincentive to broadcast old state (if they
+    hold 0 sats on their side of the channel, there is nothing to lose).
+    */
+    uint64 reserve_sat = 6;
+
+    /*
+    The maximum amount of funds in millisatoshis that we allow the remote peer
+    to have in outstanding htlcs.
+    */
+    uint64 in_flight_max_msat = 7;
+
+    /*
+    The maximum number of htlcs that the remote peer can offer us.
+    */
+    uint32 max_htlc_count = 8;
+
+    /*
+    The minimum value in millisatoshis for incoming htlcs on the channel.
+    */
+    uint64 min_htlc_in = 9;
+
+    /*
+    The number of confirmations we require before we consider the channel open.
+    */
+    uint32 min_accept_depth = 10;
 }
 
 message ChannelPoint {
@@ -839,14 +987,25 @@ message EstimateFeeRequest {
     // The target number of blocks that this transaction should be confirmed
     // by.
     int32 target_conf = 2;
+
+    // The minimum number of confirmations each one of your outputs used for
+    // the transaction must satisfy.
+    int32 min_confs = 3;
+
+    // Whether unconfirmed outputs should be used as inputs for the transaction.
+    bool spend_unconfirmed = 4;
 }
 
 message EstimateFeeResponse {
     // The total fee in satoshis.
     int64 fee_sat = 1;
 
-    // The fee rate in satoshi/byte.
-    int64 feerate_sat_per_byte = 2;
+    // Deprecated, use sat_per_vbyte.
+    // The fee rate in satoshi/vbyte.
+    int64 feerate_sat_per_byte = 2 [deprecated = true];
+
+    // The fee rate in satoshi/vbyte.
+    uint64 sat_per_vbyte = 3;
 }
 
 message SendManyRequest {
@@ -857,9 +1016,14 @@ message SendManyRequest {
     // by.
     int32 target_conf = 3;
 
-    // A manual fee rate set in sat/byte that should be used when crafting the
+    // A manual fee rate set in sat/vbyte that should be used when crafting the
     // transaction.
-    int64 sat_per_byte = 5;
+    uint64 sat_per_vbyte = 4;
+
+    // Deprecated, use sat_per_vbyte.
+    // A manual fee rate set in sat/vbyte that should be used when crafting the
+    // transaction.
+    int64 sat_per_byte = 5 [deprecated = true];
 
     // An optional label for the transaction, limited to 500 characters.
     string label = 6;
@@ -887,9 +1051,14 @@ message SendCoinsRequest {
     // by.
     int32 target_conf = 3;
 
-    // A manual fee rate set in sat/byte that should be used when crafting the
+    // A manual fee rate set in sat/vbyte that should be used when crafting the
     // transaction.
-    int64 sat_per_byte = 5;
+    uint64 sat_per_vbyte = 4;
+
+    // Deprecated, use sat_per_vbyte.
+    // A manual fee rate set in sat/vbyte that should be used when crafting the
+    // transaction.
+    int64 sat_per_byte = 5 [deprecated = true];
 
     /*
     If set, then the amount field will be ignored, and lnd will attempt to
@@ -919,6 +1088,9 @@ message ListUnspentRequest {
 
     // The maximum number of confirmations to be included.
     int32 max_confs = 2;
+
+    // An optional filter to only include outputs belonging to an account.
+    string account = 3;
 }
 message ListUnspentResponse {
     // A list of utxos
@@ -939,8 +1111,14 @@ enum AddressType {
 }
 
 message NewAddressRequest {
-    // The address type
+    // The type of address to generate.
     AddressType type = 1;
+
+    /*
+    The name of the account to generate a new address for. If empty, the
+    default wallet account is used.
+    */
+    string account = 2;
 }
 message NewAddressResponse {
     // The newly generated wallet address
@@ -953,6 +1131,12 @@ message SignMessageRequest {
     base64.
     */
     bytes msg = 1;
+
+    /*
+    Instead of the default double-SHA256 hashing of the message before signing,
+    only use one round of hashing instead.
+    */
+    bool single_hash = 2;
 }
 message SignMessageResponse {
     // The signature for the given message
@@ -1006,14 +1190,34 @@ message HTLC {
     int64 amount = 2;
     bytes hash_lock = 3;
     uint32 expiration_height = 4;
+
+    // Index identifying the htlc on the channel.
+    uint64 htlc_index = 5;
+
+    // If this HTLC is involved in a forwarding operation, this field indicates
+    // the forwarding channel. For an outgoing htlc, it is the incoming channel.
+    // For an incoming htlc, it is the outgoing channel. When the htlc
+    // originates from this node or this node is the final destination,
+    // forwarding_channel will be zero. The forwarding channel will also be zero
+    // for htlcs that need to be forwarded but don't have a forwarding decision
+    // persisted yet.
+    uint64 forwarding_channel = 6;
+
+    // Index identifying the htlc on the forwarding channel.
+    uint64 forwarding_htlc_index = 7;
 }
 
 enum CommitmentType {
     /*
+    Returned when the commitment type isn't known or unavailable.
+    */
+    UNKNOWN_COMMITMENT_TYPE = 0;
+
+    /*
     A channel using the legacy commitment format having tweaked to_remote
     keys.
     */
-    LEGACY = 0;
+    LEGACY = 1;
 
     /*
     A channel that uses the modern commitment format where the key in the
@@ -1021,19 +1225,23 @@ enum CommitmentType {
     up and recovery easier as when the channel is closed, the funds go
     directly to that key.
     */
-    STATIC_REMOTE_KEY = 1;
+    STATIC_REMOTE_KEY = 2;
 
     /*
     A channel that uses a commitment format that has anchor outputs on the
     commitments, allowing fee bumping after a force close transaction has
     been broadcast.
     */
-    ANCHORS = 2;
+    ANCHORS = 3;
 
     /*
-    Returned when the commitment type isn't known or unavailable.
+    A channel that uses a commitment type that builds upon the anchors
+    commitment format, but in addition requires a CLTV clause to spend outputs
+    paying to the channel initiator. This is intended for use on leased channels
+    to guarantee that the channel initiator has no incentives to close a leased
+    channel before its maturity date.
     */
-    UNKNOWN_COMMITMENT_TYPE = 999;
+    SCRIPT_ENFORCED_LEASE = 4;
 }
 
 message ChannelConstraints {
@@ -1420,6 +1628,11 @@ message Peer {
         Denotes that we are not receiving new graph updates from the peer.
         */
         PASSIVE_SYNC = 2;
+
+        /*
+        Denotes that this peer is pinned into an active sync.
+        */
+        PINNED_SYNC = 3;
     }
 
     // The type of sync we are currently performing with this peer.
@@ -1450,6 +1663,11 @@ message Peer {
     zero, we have not observed any flaps for this peer.
     */
     int64 last_flap_ns = 14;
+
+    /*
+    The last ping payload the peer has sent to us.
+    */
+    bytes last_ping_payload = 15;
 }
 
 message TimestampedError {
@@ -1608,9 +1826,10 @@ message CloseChannelRequest {
     // confirmed by.
     int32 target_conf = 3;
 
-    // A manual fee rate set in sat/byte that should be used when crafting the
+    // Deprecated, use sat_per_vbyte.
+    // A manual fee rate set in sat/vbyte that should be used when crafting the
     // closure transaction.
-    int64 sat_per_byte = 4;
+    int64 sat_per_byte = 4 [deprecated = true];
 
     /*
     An optional address to send funds to in the case of a cooperative close.
@@ -1619,6 +1838,10 @@ message CloseChannelRequest {
     to the upfront shutdown addresss.
     */
     string delivery_address = 5;
+
+    // A manual fee rate set in sat/vbyte that should be used when crafting the
+    // closure transaction.
+    uint64 sat_per_vbyte = 6;
 }
 
 message CloseStatusUpdate {
@@ -1655,7 +1878,89 @@ message ReadyForPsbtFunding {
     bytes psbt = 3;
 }
 
+message BatchOpenChannelRequest {
+    // The list of channels to open.
+    repeated BatchOpenChannel channels = 1;
+
+    // The target number of blocks that the funding transaction should be
+    // confirmed by.
+    int32 target_conf = 2;
+
+    // A manual fee rate set in sat/vByte that should be used when crafting the
+    // funding transaction.
+    int64 sat_per_vbyte = 3;
+
+    // The minimum number of confirmations each one of your outputs used for
+    // the funding transaction must satisfy.
+    int32 min_confs = 4;
+
+    // Whether unconfirmed outputs should be used as inputs for the funding
+    // transaction.
+    bool spend_unconfirmed = 5;
+
+    // An optional label for the batch transaction, limited to 500 characters.
+    string label = 6;
+}
+
+message BatchOpenChannel {
+    // The pubkey of the node to open a channel with. When using REST, this
+    // field must be encoded as base64.
+    bytes node_pubkey = 1;
+
+    // The number of satoshis the wallet should commit to the channel.
+    int64 local_funding_amount = 2;
+
+    // The number of satoshis to push to the remote side as part of the initial
+    // commitment state.
+    int64 push_sat = 3;
+
+    // Whether this channel should be private, not announced to the greater
+    // network.
+    bool private = 4;
+
+    // The minimum value in millisatoshi we will require for incoming HTLCs on
+    // the channel.
+    int64 min_htlc_msat = 5;
+
+    // The delay we require on the remote's commitment transaction. If this is
+    // not set, it will be scaled automatically with the channel size.
+    uint32 remote_csv_delay = 6;
+
+    /*
+    Close address is an optional address which specifies the address to which
+    funds should be paid out to upon cooperative close. This field may only be
+    set if the peer supports the option upfront feature bit (call listpeers
+    to check). The remote peer will only accept cooperative closes to this
+    address if it is set.
+
+    Note: If this value is set on channel creation, you will *not* be able to
+    cooperatively close out to a different address.
+    */
+    string close_address = 7;
+
+    /*
+    An optional, unique identifier of 32 random bytes that will be used as the
+    pending channel ID to identify the channel while it is in the pre-pending
+    state.
+    */
+    bytes pending_chan_id = 8;
+
+    /*
+    The explicit commitment type to use. Note this field will only be used if
+    the remote peer supports explicit channel negotiation.
+    */
+    CommitmentType commitment_type = 9;
+}
+
+message BatchOpenChannelResponse {
+    repeated PendingUpdate pending_channels = 1;
+}
+
 message OpenChannelRequest {
+    // A manual fee rate set in sat/vbyte that should be used when crafting the
+    // funding transaction.
+    uint64 sat_per_vbyte = 1;
+
     /*
     The pubkey of the node to open a channel with. When using REST, this field
     must be encoded as base64.
@@ -1679,9 +1984,10 @@ message OpenChannelRequest {
     // confirmed by.
     int32 target_conf = 6;
 
-    // A manual fee rate set in sat/byte that should be used when crafting the
+    // Deprecated, use sat_per_vbyte.
+    // A manual fee rate set in sat/vbyte that should be used when crafting the
     // funding transaction.
-    int64 sat_per_byte = 7;
+    int64 sat_per_byte = 7 [deprecated = true];
 
     // Whether this channel should be private, not announced to the greater
     // network.
@@ -1735,6 +2041,18 @@ message OpenChannelRequest {
     to the commitment transaction.
     */
     uint32 remote_max_htlcs = 16;
+
+    /*
+    Max local csv is the maximum csv delay we will allow for our own commitment
+    transaction.
+    */
+    uint32 max_local_csv = 17;
+
+    /*
+    The explicit commitment type to use. Note this field will only be used if
+    the remote peer supports explicit channel negotiation.
+    */
+    CommitmentType commitment_type = 18;
 }
 message OpenStatusUpdate {
     oneof update {
@@ -1874,6 +2192,20 @@ message FundingPsbtVerify {
 
     // The pending channel ID of the channel to get the PSBT for.
     bytes pending_chan_id = 2;
+
+    /*
+    Can only be used if the no_publish flag was set to true in the OpenChannel
+    call meaning that the caller is solely responsible for publishing the final
+    funding transaction. If skip_finalize is set to true then lnd will not wait
+    for a FundingPsbtFinalize state step and instead assumes that a transaction
+    with the same TXID as the passed in PSBT will eventually confirm.
+    IT IS ABSOLUTELY IMPERATIVE that the TXID of the transaction that is
+    eventually published does have the _same TXID_ as the verified PSBT. That
+    means no inputs or outputs can change, only signatures can be added. If the
+    TXID changes between this call and the publish step then the channel will
+    never be created and the funds will be in limbo.
+    */
+    bool skip_finalize = 3;
 }
 
 message FundingPsbtFinalize {
@@ -1978,6 +2310,12 @@ message PendingChannelsResponse {
 
         // The commitment type used by this channel.
         CommitmentType commitment_type = 9;
+
+        // Total number of forwarding packages created in this channel.
+        int64 num_forwarding_packages = 10;
+
+        // A set of flags showing the current state of the channel.
+        string chan_status_flags = 11;
     }
 
     message PendingOpenChannel {
@@ -2019,6 +2357,9 @@ message PendingChannelsResponse {
         this point.
         */
         Commitments commitments = 3;
+
+        // The transaction id of the closing transaction
+        string closing_txid = 4;
     }
 
     message Commitments {
@@ -2122,6 +2463,7 @@ message ChannelEventUpdate {
         ChannelPoint active_channel = 3;
         ChannelPoint inactive_channel = 4;
         PendingUpdate pending_open_channel = 6;
+        ChannelPoint fully_resolved_channel = 7;
     }
 
     enum UpdateType {
@@ -2130,13 +2472,23 @@ message ChannelEventUpdate {
         ACTIVE_CHANNEL = 2;
         INACTIVE_CHANNEL = 3;
         PENDING_OPEN_CHANNEL = 4;
+        FULLY_RESOLVED_CHANNEL = 5;
     }
 
     UpdateType type = 5;
 }
 
+message WalletAccountBalance {
+    // The confirmed balance of the account (with >= 1 confirmations).
+    int64 confirmed_balance = 1;
+
+    // The unconfirmed balance of the account (with 0 confirmations).
+    int64 unconfirmed_balance = 2;
+}
+
 message WalletBalanceRequest {
 }
+
 message WalletBalanceResponse {
     // The balance of the wallet
     int64 total_balance = 1;
@@ -2146,6 +2498,9 @@ message WalletBalanceResponse {
 
     // The unconfirmed balance of a wallet(with 0 confirmations)
     int64 unconfirmed_balance = 3;
+
+    // A mapping of each wallet account's name to its balance.
+    map<string, WalletAccountBalance> account_balance = 4;
 }
 
 message Amount {
@@ -2217,7 +2572,8 @@ message QueryRoutesRequest {
     The maximum number of satoshis that will be paid as a fee of the payment.
     This value can be represented either as a percentage of the amount being
     sent, or as a fixed amount of the maximum fee the user is willing the pay to
-    send the payment.
+    send the payment. If not specified, lnd will use a default value of 100%
+    fees for small amounts (<=1k sat) or 5% fees for larger amounts.
     */
     FeeLimit fee_limit = 5;
 
@@ -2260,7 +2616,7 @@ message QueryRoutesRequest {
     An optional field that can be used to pass an arbitrary set of TLV records
     to a peer which understands the new records. This can be used to pass
     application specific data during the payment attempt. If the destination
-    does not support the specified recrods, and error will be returned.
+    does not support the specified records, an error will be returned.
     Record types are required to be in the custom range >= 65536. When using
     REST, the values must be encoded as base64.
     */
@@ -2340,7 +2696,7 @@ message Hop {
     output index for the channel.
     */
     uint64 chan_id = 1 [jstype = JS_STRING];
-    int64 chan_capacity = 2;
+    int64 chan_capacity = 2 [deprecated = true];
     int64 amt_to_forward = 3 [deprecated = true];
     int64 fee = 4 [deprecated = true];
     uint32 expiry = 5;
@@ -2362,11 +2718,21 @@ message Hop {
 
     /*
     An optional TLV record that signals the use of an MPP payment. If present,
-    the receiver will enforce that that the same mpp_record is included in the
-    final hop payload of all non-zero payments in the HTLC set. If empty, a
-    regular single-shot payment is or was attempted.
+    the receiver will enforce that the same mpp_record is included in the final
+    hop payload of all non-zero payments in the HTLC set. If empty, a regular
+    single-shot payment is or was attempted.
     */
     MPPRecord mpp_record = 10;
+
+    /*
+    An optional TLV record that signals the use of an AMP payment. If present,
+    the receiver will treat all received payments including the same
+    (payment_addr, set_id) pair  as being part of one logical payment. The
+    payment will be settled by XORing the root_share's together and deriving the
+    child hashes and preimages according to BOLT XX. Must be used in conjunction
+    with mpp_record.
+    */
+    AMPRecord amp_record = 12;
 
     /*
     An optional set of key-value TLV records. This is useful within the context
@@ -2392,6 +2758,14 @@ message MPPRecord {
     total_amt_msat must be used on all subpayments.
     */
     int64 total_amt_msat = 10;
+}
+
+message AMPRecord {
+    bytes root_share = 1;
+
+    bytes set_id = 2;
+
+    uint32 child_index = 3;
 }
 
 /*
@@ -2619,11 +2993,27 @@ message GraphTopologyUpdate {
     repeated ClosedChannelUpdate closed_chans = 3;
 }
 message NodeUpdate {
-    repeated string addresses = 1;
+    /*
+    Deprecated, use node_addresses.
+    */
+    repeated string addresses = 1 [deprecated = true];
+
     string identity_key = 2;
-    bytes global_features = 3;
+
+    /*
+    Deprecated, use features.
+    */
+    bytes global_features = 3 [deprecated = true];
+
     string alias = 4;
     string color = 5;
+    repeated NodeAddress node_addresses = 7;
+
+    /*
+    Features that the node has advertised in the init message, node
+    announcements and invoices.
+    */
+    map<uint32, Feature> features = 6;
 }
 message ChannelEdgeUpdate {
     /*
@@ -2674,12 +3064,30 @@ message HopHint {
     uint32 cltv_expiry_delta = 5;
 }
 
+message SetID {
+    bytes set_id = 1;
+}
+
 message RouteHint {
     /*
     A list of hop hints that when chained together can assist in reaching a
     specific destination.
     */
     repeated HopHint hop_hints = 1;
+}
+
+message AMPInvoiceState {
+    // The state the HTLCs associated with this setID are in.
+    InvoiceHTLCState state = 1;
+
+    // The settle index of this HTLC set, if the invoice state is settled.
+    uint64 settle_index = 2;
+
+    // The time this HTLC set was settled expressed in unix epoch.
+    int64 settle_time = 3;
+
+    // The total amount paid for the sub-invoice expressed in milli satoshis.
+    int64 amt_paid_msat = 5;
 }
 
 message Invoice {
@@ -2824,6 +3232,28 @@ message Invoice {
     [EXPERIMENTAL].
     */
     bool is_keysend = 25;
+
+    /*
+    The payment address of this invoice. This value will be used in MPP
+    payments, and also for newer invoices that always require the MPP payload
+    for added end-to-end security.
+    */
+    bytes payment_addr = 26;
+
+    /*
+    Signals whether or not this is an AMP invoice.
+    */
+    bool is_amp = 27;
+
+    /*
+    [EXPERIMENTAL]:
+
+    Maps a 32-byte hex-encoded set ID to the sub-invoice AMP state for the
+    given set ID. This field is always populated for AMP invoices, and can be
+    used along side LookupInvoice to obtain the HTLC information related to a
+    given sub-invoice.
+    */
+    map<string, AMPInvoiceState> amp_invoice_state = 28;
 }
 
 enum InvoiceHTLCState {
@@ -2863,6 +3293,31 @@ message InvoiceHTLC {
 
     // The total amount of the mpp payment in msat.
     uint64 mpp_total_amt_msat = 10;
+
+    // Details relevant to AMP HTLCs, only populated if this is an AMP HTLC.
+    AMP amp = 11;
+}
+
+// Details specific to AMP HTLCs.
+message AMP {
+    // An n-of-n secret share of the root seed from which child payment hashes
+    // and preimages are derived.
+    bytes root_share = 1;
+
+    // An identifier for the HTLC set that this HTLC belongs to.
+    bytes set_id = 2;
+
+    // A nonce used to randomize the child preimage and child hash from a given
+    // root_share.
+    uint32 child_index = 3;
+
+    // The payment hash of the AMP HTLC.
+    bytes hash = 4;
+
+    // The preimage used to settle this AMP htlc. This field will only be
+    // populated if the invoice is in InvoiceState_ACCEPTED or
+    // InvoiceState_SETTLED.
+    bytes preimage = 5;
 }
 
 message AddInvoiceResponse {
@@ -2882,6 +3337,13 @@ message AddInvoiceResponse {
     invoices with an add_index greater than this one.
     */
     uint64 add_index = 16;
+
+    /*
+    The payment address of the generated invoice. This value should be used
+    in all payments for this invoice as we require it for end to end
+    security.
+    */
+    bytes payment_addr = 17;
 }
 message PaymentHash {
     /*
@@ -3053,6 +3515,9 @@ message Payment {
 }
 
 message HTLCAttempt {
+    // The unique ID that is used for this attempt.
+    uint64 attempt_id = 7;
+
     enum HTLCStatus {
         IN_FLIGHT = 0;
         SUCCEEDED = 1;
@@ -3127,7 +3592,27 @@ message ListPaymentsResponse {
     uint64 last_index_offset = 3;
 }
 
+message DeletePaymentRequest {
+    // Payment hash to delete.
+    bytes payment_hash = 1;
+
+    /*
+    Only delete failed HTLCs from the payment, not the payment itself.
+    */
+    bool failed_htlcs_only = 2;
+}
+
 message DeleteAllPaymentsRequest {
+    // Only delete failed payments.
+    bool failed_payments_only = 1;
+
+    /*
+    Only delete failed HTLCs from payments, not the payment itself.
+    */
+    bool failed_htlcs_only = 2;
+}
+
+message DeletePaymentResponse {
 }
 
 message DeleteAllPaymentsResponse {
@@ -3137,6 +3622,13 @@ message AbandonChannelRequest {
     ChannelPoint channel_point = 1;
 
     bool pending_funding_shim_only = 2;
+
+    /*
+    Override the requirement for being in dev mode by setting this to true and
+    confirming the user knows what they are doing and this is a potential foot
+    gun to lose funds if used on active channels.
+    */
+    bool i_know_what_i_am_doing = 3;
 }
 
 message AbandonChannelResponse {
@@ -3188,6 +3680,14 @@ enum FeatureBit {
     PAYMENT_ADDR_OPT = 15;
     MPP_REQ = 16;
     MPP_OPT = 17;
+    WUMBO_CHANNELS_REQ = 18;
+    WUMBO_CHANNELS_OPT = 19;
+    ANCHORS_REQ = 20;
+    ANCHORS_OPT = 21;
+    ANCHORS_ZERO_FEE_HTLC_REQ = 22;
+    ANCHORS_ZERO_FEE_HTLC_OPT = 23;
+    AMP_REQ = 30;
+    AMP_OPT = 31;
 }
 
 message Feature {
@@ -3250,6 +3750,9 @@ message PolicyUpdateRequest {
     // goes up to 6 decimal places, so 1e-6.
     double fee_rate = 4;
 
+    // The effective fee rate in micro-satoshis (parts per million).
+    uint32 fee_rate_ppm = 9;
+
     // The required timelock delta for HTLCs forwarded over the channel.
     uint32 time_lock_delta = 5;
 
@@ -3264,7 +3767,28 @@ message PolicyUpdateRequest {
     // If true, min_htlc_msat is applied.
     bool min_htlc_msat_specified = 8;
 }
+enum UpdateFailure {
+    UPDATE_FAILURE_UNKNOWN = 0;
+    UPDATE_FAILURE_PENDING = 1;
+    UPDATE_FAILURE_NOT_FOUND = 2;
+    UPDATE_FAILURE_INTERNAL_ERR = 3;
+    UPDATE_FAILURE_INVALID_PARAMETER = 4;
+}
+
+message FailedUpdate {
+    // The outpoint in format txid:n
+    OutPoint outpoint = 1;
+
+    // Reason for the policy update failure.
+    UpdateFailure reason = 2;
+
+    // A string representation of the policy update error.
+    string update_error = 3;
+}
+
 message PolicyUpdateResponse {
+    // List of failed policy updates.
+    repeated FailedUpdate failed_updates = 1;
 }
 
 message ForwardingHistoryRequest {
@@ -3288,8 +3812,8 @@ message ForwardingHistoryRequest {
 }
 message ForwardingEvent {
     // Timestamp is the time (unix epoch offset) that this circuit was
-    // completed.
-    uint64 timestamp = 1;
+    // completed. Deprecated by timestamp_ns.
+    uint64 timestamp = 1 [deprecated = true];
 
     // The incoming channel ID that carried the HTLC that created the circuit.
     uint64 chan_id_in = 2 [jstype = JS_STRING];
@@ -3319,6 +3843,10 @@ message ForwardingEvent {
     // The total amount (in milli-satoshis) of the outgoing HTLC that created
     // the second half of the circuit.
     uint64 amt_out_msat = 10;
+
+    // The number of nanoseconds elapsed since January 1, 1970 UTC when this
+    // circuit was completed.
+    uint64 timestamp_ns = 11;
 
     // TODO(roasbeef): add settlement latency?
     //  * use FPE on the chan id?
@@ -3428,6 +3956,12 @@ message BakeMacaroonRequest {
 
     // The root key ID used to create the macaroon, must be a positive integer.
     uint64 root_key_id = 2;
+
+    /*
+    Informs the RPC on whether to allow external permissions that LND is not
+    aware of.
+    */
+    bool allow_external_permissions = 3;
 }
 message BakeMacaroonResponse {
     // The hex encoded macaroon, serialized in binary format.
@@ -3497,6 +4031,7 @@ message Failure {
         PERMANENT_CHANNEL_FAILURE = 21;
         EXPIRY_TOO_FAR = 22;
         MPP_TIMEOUT = 23;
+        INVALID_ONION_PAYLOAD = 24;
 
         /*
         An internal error occurred.
@@ -3637,4 +4172,211 @@ message MacaroonId {
 message Op {
     string entity = 1;
     repeated string actions = 2;
+}
+
+message CheckMacPermRequest {
+    bytes macaroon = 1;
+    repeated MacaroonPermission permissions = 2;
+    string fullMethod = 3;
+}
+
+message CheckMacPermResponse {
+    bool valid = 1;
+}
+
+message RPCMiddlewareRequest {
+    /*
+    The unique ID of the intercepted original gRPC request. Useful for mapping
+    request to response when implementing full duplex message interception. For
+    streaming requests, this will be the same ID for all incoming and outgoing
+    middleware intercept messages of the _same_ stream.
+    */
+    uint64 request_id = 1;
+
+    /*
+    The raw bytes of the complete macaroon as sent by the gRPC client in the
+    original request. This might be empty for a request that doesn't require
+    macaroons such as the wallet unlocker RPCs.
+    */
+    bytes raw_macaroon = 2;
+
+    /*
+    The parsed condition of the macaroon's custom caveat for convenient access.
+    This field only contains the value of the custom caveat that the handling
+    middleware has registered itself for. The condition _must_ be validated for
+    messages of intercept_type stream_auth and request!
+    */
+    string custom_caveat_condition = 3;
+
+    /*
+    There are three types of messages that will be sent to the middleware for
+    inspection and approval: Stream authentication, request and response
+    interception. The first two can only be accepted (=forward to main RPC
+    server) or denied (=return error to client). Intercepted responses can also
+    be replaced/overwritten.
+    */
+    oneof intercept_type {
+        /*
+        Intercept stream authentication: each new streaming RPC call that is
+        initiated against lnd and contains the middleware's custom macaroon
+        caveat can be approved or denied based upon the macaroon in the stream
+        header. This message will only be sent for streaming RPCs, unary RPCs
+        must handle the macaroon authentication in the request interception to
+        avoid an additional message round trip between lnd and the middleware.
+        */
+        StreamAuth stream_auth = 4;
+
+        /*
+        Intercept incoming gRPC client request message: all incoming messages,
+        both on streaming and unary RPCs, are forwarded to the middleware for
+        inspection. For unary RPC messages the middleware is also expected to
+        validate the custom macaroon caveat of the request.
+        */
+        RPCMessage request = 5;
+
+        /*
+        Intercept outgoing gRPC response message: all outgoing messages, both on
+        streaming and unary RPCs, are forwarded to the middleware for inspection
+        and amendment. The response in this message is the original response as
+        it was generated by the main RPC server. It can either be accepted
+        (=forwarded to the client), replaced/overwritten with a new message of
+        the same type, or replaced by an error message.
+        */
+        RPCMessage response = 6;
+    }
+
+    /*
+    The unique message ID of this middleware intercept message. There can be
+    multiple middleware intercept messages per single gRPC request (one for the
+    incoming request and one for the outgoing response) or gRPC stream (one for
+    each incoming message and one for each outgoing response). This message ID
+    must be referenced when responding (accepting/rejecting/modifying) to an
+    intercept message.
+    */
+    uint64 msg_id = 7;
+}
+
+message StreamAuth {
+    /*
+    The full URI (in the format /<rpcpackage>.<ServiceName>/MethodName, for
+    example /lnrpc.Lightning/GetInfo) of the streaming RPC method that was just
+    established.
+    */
+    string method_full_uri = 1;
+}
+
+message RPCMessage {
+    /*
+    The full URI (in the format /<rpcpackage>.<ServiceName>/MethodName, for
+    example /lnrpc.Lightning/GetInfo) of the RPC method the message was sent
+    to/from.
+    */
+    string method_full_uri = 1;
+
+    /*
+    Indicates whether the message was sent over a streaming RPC method or not.
+    */
+    bool stream_rpc = 2;
+
+    /*
+    The full canonical gRPC name of the message type (in the format
+    <rpcpackage>.TypeName, for example lnrpc.GetInfoRequest).
+    */
+    string type_name = 3;
+
+    /*
+    The full content of the gRPC message, serialized in the binary protobuf
+    format.
+    */
+    bytes serialized = 4;
+}
+
+message RPCMiddlewareResponse {
+    /*
+    The request message ID this response refers to. Must always be set when
+    giving feedback to an intercept but is ignored for the initial registration
+    message.
+    */
+    uint64 ref_msg_id = 1;
+
+    /*
+    The middleware can only send two types of messages to lnd: The initial
+    registration message that identifies the middleware and after that only
+    feedback messages to requests sent to the middleware.
+    */
+    oneof middleware_message {
+        /*
+        The registration message identifies the middleware that's being
+        registered in lnd. The registration message must be sent immediately
+        after initiating the RegisterRpcMiddleware stream, otherwise lnd will
+        time out the attempt and terminate the request. NOTE: The middleware
+        will only receive interception messages for requests that contain a
+        macaroon with the custom caveat that the middleware declares it is
+        responsible for handling in the registration message! As a security
+        measure, _no_ middleware can intercept requests made with _unencumbered_
+        macaroons!
+        */
+        MiddlewareRegistration register = 2;
+
+        /*
+        The middleware received an interception request and gives feedback to
+        it. The request_id indicates what message the feedback refers to.
+        */
+        InterceptFeedback feedback = 3;
+    }
+}
+
+message MiddlewareRegistration {
+    /*
+    The name of the middleware to register. The name should be as informative
+    as possible and is logged on registration.
+    */
+    string middleware_name = 1;
+
+    /*
+    The name of the custom macaroon caveat that this middleware is responsible
+    for. Only requests/responses that contain a macaroon with the registered
+    custom caveat are forwarded for interception to the middleware. The
+    exception being the read-only mode: All requests/responses are forwarded to
+    a middleware that requests read-only access but such a middleware won't be
+    allowed to _alter_ responses. As a security measure, _no_ middleware can
+    change responses to requests made with _unencumbered_ macaroons!
+    NOTE: Cannot be used at the same time as read_only_mode.
+    */
+    string custom_macaroon_caveat_name = 2;
+
+    /*
+    Instead of defining a custom macaroon caveat name a middleware can register
+    itself for read-only access only. In that mode all requests/responses are
+    forwarded to the middleware but the middleware isn't allowed to alter any of
+    the responses.
+    NOTE: Cannot be used at the same time as custom_macaroon_caveat_name.
+    */
+    bool read_only_mode = 3;
+}
+
+message InterceptFeedback {
+    /*
+    The error to return to the user. If this is non-empty, the incoming gRPC
+    stream/request is aborted and the error is returned to the gRPC client. If
+    this value is empty, it means the middleware accepts the stream/request/
+    response and the processing of it can continue.
+    */
+    string error = 1;
+
+    /*
+    A boolean indicating that the gRPC response should be replaced/overwritten.
+    As its name suggests, this can only be used as a feedback to an intercepted
+    response RPC message and is ignored for feedback on any other message. This
+    boolean is needed because in protobuf an empty message is serialized as a
+    0-length or nil byte slice and we wouldn't be able to distinguish between
+    an empty replacement message and the "don't replace anything" case.
+    */
+    bool replace_response = 2;
+
+    /*
+    If the replace_response field is set to true, this field must contain the
+    binary serialized gRPC response message in the protobuf format.
+    */
+    bytes replacement_serialized = 3;
 }

--- a/proto/router.proto
+++ b/proto/router.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-import "rpc.proto";
+import "lightning.proto";
 
 package routerrpc;
 
@@ -62,6 +62,28 @@ service Router {
         returns (QueryMissionControlResponse);
 
     /*
+    XImportMissionControl is an experimental API that imports the state provided
+    to the internal mission control's state, using all results which are more
+    recent than our existing values. These values will only be imported
+    in-memory, and will not be persisted across restarts.
+    */
+    rpc XImportMissionControl (XImportMissionControlRequest)
+        returns (XImportMissionControlResponse);
+
+    /*
+    GetMissionControlConfig returns mission control's current config.
+    */
+    rpc GetMissionControlConfig (GetMissionControlConfigRequest)
+        returns (GetMissionControlConfigResponse);
+
+    /*
+    SetMissionControlConfig will set mission control's config, if the config
+    provided is valid.
+    */
+    rpc SetMissionControlConfig (SetMissionControlConfigRequest)
+        returns (SetMissionControlConfigResponse);
+
+    /*
     QueryProbability returns the current success probability estimate for a
     given node pair and amount.
     */
@@ -108,6 +130,15 @@ service Router {
     */
     rpc HtlcInterceptor (stream ForwardHtlcInterceptResponse)
         returns (stream ForwardHtlcInterceptRequest);
+
+    /*
+    UpdateChanStatus attempts to manually set the state of a channel
+    (enabled, disabled, or auto). A manual "disable" request will cause the
+    channel to stay disabled until a subsequent manual request of either
+    "enable" or "auto".
+    */
+    rpc UpdateChanStatus (UpdateChanStatusRequest)
+        returns (UpdateChanStatusResponse);
 }
 
 message SendPaymentRequest {
@@ -136,6 +167,9 @@ message SendPaymentRequest {
     timelock for the final hop.
     */
     int32 final_cltv_delta = 4;
+
+    // An optional payment addr to be included within the last hop of the route.
+    bytes payment_addr = 20;
 
     /*
     A bare-bones invoice for a payment within the Lightning Network.  With the
@@ -237,6 +271,19 @@ message SendPaymentRequest {
     that show which htlcs are still in flight are suppressed.
     */
     bool no_inflight_updates = 18;
+
+    /*
+    The largest payment split that should be attempted when making a payment if
+    splitting is necessary. Setting this value will effectively cause lnd to
+    split more aggressively, vs only when it thinks it needs to. Note that this
+    value is in milli-satoshis.
+    */
+    uint64 max_shard_size_msat = 21;
+
+    /*
+    If set, an AMP-payment will be attempted.
+    */
+    bool amp = 22;
 }
 
 message TrackPaymentRequest {
@@ -310,6 +357,19 @@ message QueryMissionControlResponse {
     repeated PairHistory pairs = 2;
 }
 
+message XImportMissionControlRequest {
+    // Node pair-level mission control state to be imported.
+    repeated PairHistory pairs = 1;
+
+    // Whether to force override MC pair history. Note that even with force
+    // override the failure pair is imported before the success pair and both
+    // still clamp existing failure/success amounts.
+    bool force = 2;
+}
+
+message XImportMissionControlResponse {
+}
+
 // PairHistory contains the mission control state for a particular node pair.
 message PairHistory {
     // The source node pubkey of the pair.
@@ -349,6 +409,67 @@ message PairData {
 
     // Highest amount that we could successfully forward in millisats.
     int64 success_amt_msat = 7;
+}
+
+message GetMissionControlConfigRequest {
+}
+
+message GetMissionControlConfigResponse {
+    /*
+    Mission control's currently active config.
+    */
+    MissionControlConfig config = 1;
+}
+
+message SetMissionControlConfigRequest {
+    /*
+    The config to set for mission control. Note that all values *must* be set,
+    because the full config will be applied.
+    */
+    MissionControlConfig config = 1;
+}
+
+message SetMissionControlConfigResponse {
+}
+
+message MissionControlConfig {
+    /*
+    The amount of time mission control will take to restore a penalized node
+    or channel back to 50% success probability, expressed in seconds. Setting
+    this value to a higher value will penalize failures for longer, making
+    mission control less likely to route through nodes and channels that we
+    have previously recorded failures for.
+    */
+    uint64 half_life_seconds = 1;
+
+    /*
+    The probability of success mission control should assign to hop in a route
+    where it has no other information available. Higher values will make mission
+    control more willing to try hops that we have no information about, lower
+    values will discourage trying these hops.
+    */
+    float hop_probability = 2;
+
+    /*
+    The importance that mission control should place on historical results,
+    expressed as a value in [0;1]. Setting this value to 1 will ignore all
+    historical payments and just use the hop probability to assess the
+    probability of success for each hop. A zero value ignores hop probability
+    completely and relies entirely on historical results, unless none are
+    available.
+    */
+    float weight = 3;
+
+    /*
+    The maximum number of payment results that mission control will store.
+    */
+    uint32 maximum_payment_results = 4;
+
+    /*
+    The minimum time that must have passed since the previously recorded failure
+    before we raise the failure amount.
+    */
+    uint64 minimum_failure_relax_interval = 5;
 }
 
 message QueryProbabilityRequest {
@@ -394,6 +515,9 @@ message BuildRouteRequest {
     pubkey.
     */
     repeated bytes hop_pubkeys = 4;
+
+    // An optional payment addr to be included within the last hop of the route.
+    bytes payment_addr = 5;
 }
 
 message BuildRouteResponse {
@@ -488,6 +612,8 @@ message ForwardFailEvent {
 }
 
 message SettleEvent {
+    // The revealed preimage.
+    bytes preimage = 1;
 }
 
 message LinkFailEvent {
@@ -631,6 +757,9 @@ message ForwardHtlcInterceptRequest {
 
     // Any custom records that were present in the payload.
     map<uint64, bytes> custom_records = 8;
+
+    // The onion blob for the next hop
+    bytes onion_blob = 9;
 }
 
 /**
@@ -658,4 +787,19 @@ enum ResolveHoldForwardAction {
     SETTLE = 0;
     FAIL = 1;
     RESUME = 2;
+}
+
+message UpdateChanStatusRequest {
+    lnrpc.ChannelPoint chan_point = 1;
+
+    ChanStatusAction action = 2;
+}
+
+enum ChanStatusAction {
+    ENABLE = 0;
+    DISABLE = 1;
+    AUTO = 2;
+}
+
+message UpdateChanStatusResponse {
 }

--- a/proto/signer.proto
+++ b/proto/signer.proto
@@ -54,8 +54,9 @@ service Signer {
     /*
     DeriveSharedKey returns a shared secret key by performing Diffie-Hellman key
     derivation between the ephemeral public key in the request and the node's
-    key specified in the key_loc parameter (or the node's identity private key
-    if no key locator is specified):
+    key specified in the key_desc parameter. Either a key locator or a raw
+    public key is expected in the key_desc, if neither is supplied, defaults to
+    the node's identity private key:
         P_shared = privKeyNode * ephemeralPubkey
     The resulting shared public key is serialized in the compressed format and
     hashed with sha256, resulting in the final key length of 256bit.
@@ -73,14 +74,14 @@ message KeyLocator {
 
 message KeyDescriptor {
     /*
-    The raw bytes of the key being identified. Either this or the KeyLocator
-    must be specified.
+    The raw bytes of the public key in the key pair being identified. Either
+    this or the KeyLocator must be specified.
     */
     bytes raw_key_bytes = 1;
 
     /*
-    The key locator that identifies which key to use for signing. Either this
-    or the raw bytes of the target key must be specified.
+    The key locator that identifies which private key to use for signing.
+    Either this or the raw bytes of the target public key must be specified.
     */
     KeyLocator key_loc = 2;
 }
@@ -98,6 +99,10 @@ message SignDescriptor {
     A descriptor that precisely describes *which* key to use for signing. This
     may provide the raw public key directly, or require the Signer to re-derive
     the key according to the populated derivation path.
+
+    Note that if the key descriptor was obtained through walletrpc.DeriveKey,
+    then the key locator MUST always be provided, since the derived keys are not
+    persisted unlike with DeriveNextKey.
     */
     KeyDescriptor key_desc = 1;
 
@@ -185,6 +190,15 @@ message SignMessageReq {
 
     // The key locator that identifies which key to use for signing.
     KeyLocator key_loc = 2;
+
+    // Double-SHA256 hash instead of just the default single round.
+    bool double_hash = 3;
+
+    /*
+    Use the compact (pubkey recoverable) format instead of the raw lnwire
+    format.
+    */
+    bool compact_sig = 4;
 }
 message SignMessageResp {
     /*
@@ -216,10 +230,18 @@ message SharedKeyRequest {
     bytes ephemeral_pubkey = 1;
 
     /*
-    The optional key locator of the local key that should be used. If this
-    parameter is not set then the node's identity private key will be used.
+    Deprecated. The optional key locator of the local key that should be used.
+    If this parameter is not set then the node's identity private key will be
+    used.
     */
-    KeyLocator key_loc = 2;
+    KeyLocator key_loc = 2 [deprecated = true];
+
+    /*
+    A key descriptor describes the key used for performing ECDH. Either a key
+    locator or a raw public key is expected, if neither is supplied, defaults to
+    the node's identity private key.
+    */
+    KeyDescriptor key_desc = 3;
 }
 
 message SharedKeyResponse {

--- a/proto/walletkit.proto
+++ b/proto/walletkit.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-import "rpc.proto";
+import "lightning.proto";
 import "signer.proto";
 
 package walletrpc;
@@ -33,6 +33,11 @@ service WalletKit {
     rpc ReleaseOutput (ReleaseOutputRequest) returns (ReleaseOutputResponse);
 
     /*
+    ListLeases lists all currently locked utxos.
+    */
+    rpc ListLeases (ListLeasesRequest) returns (ListLeasesResponse);
+
+    /*
     DeriveNextKey attempts to derive the *next* key within the key family
     (account in BIP43) specified. This method should return the next external
     child within this branch.
@@ -49,6 +54,50 @@ service WalletKit {
     NextAddr returns the next unused address within the wallet.
     */
     rpc NextAddr (AddrRequest) returns (AddrResponse);
+
+    /*
+    ListAccounts retrieves all accounts belonging to the wallet by default. A
+    name and key scope filter can be provided to filter through all of the
+    wallet accounts and return only those matching.
+    */
+    rpc ListAccounts (ListAccountsRequest) returns (ListAccountsResponse);
+
+    /*
+    ImportAccount imports an account backed by an account extended public key.
+    The master key fingerprint denotes the fingerprint of the root key
+    corresponding to the account public key (also known as the key with
+    derivation path m/). This may be required by some hardware wallets for
+    proper identification and signing.
+
+    The address type can usually be inferred from the key's version, but may be
+    required for certain keys to map them into the proper scope.
+
+    For BIP-0044 keys, an address type must be specified as we intend to not
+    support importing BIP-0044 keys into the wallet using the legacy
+    pay-to-pubkey-hash (P2PKH) scheme. A nested witness address type will force
+    the standard BIP-0049 derivation scheme, while a witness address type will
+    force the standard BIP-0084 derivation scheme.
+
+    For BIP-0049 keys, an address type must also be specified to make a
+    distinction between the standard BIP-0049 address schema (nested witness
+    pubkeys everywhere) and our own BIP-0049Plus address schema (nested pubkeys
+    externally, witness pubkeys internally).
+
+    NOTE: Events (deposits/spends) for keys derived from an account will only be
+    detected by lnd if they happen after the import. Rescans to detect past
+    events will be supported later on.
+    */
+    rpc ImportAccount (ImportAccountRequest) returns (ImportAccountResponse);
+
+    /*
+    ImportPublicKey imports a public key as watch-only into the wallet.
+
+    NOTE: Events (deposits/spends) for a key will only be detected by lnd if
+    they happen after the import. Rescans to detect past events will be
+    supported later on.
+    */
+    rpc ImportPublicKey (ImportPublicKeyRequest)
+        returns (ImportPublicKeyResponse);
 
     /*
     PublishTransaction attempts to publish the passed transaction to the
@@ -152,6 +201,21 @@ service WalletKit {
     rpc FundPsbt (FundPsbtRequest) returns (FundPsbtResponse);
 
     /*
+    SignPsbt expects a partial transaction with all inputs and outputs fully
+    declared and tries to sign all unsigned inputs that have all required fields
+    (UTXO information, BIP32 derivation information, witness or sig scripts)
+    set.
+    If no error is returned, the PSBT is ready to be given to the next signer or
+    to be finalized if lnd was the last signer.
+
+    NOTE: This RPC only signs inputs (and only those it can sign), it does not
+    perform any other tasks (such as coin selection, UTXO locking or
+    input/output/fee value validation, PSBT finalization). Any input that is
+    incomplete will be skipped.
+    */
+    rpc SignPsbt (SignPsbtRequest) returns (SignPsbtResponse);
+
+    /*
     FinalizePsbt expects a partial transaction with all inputs and outputs fully
     declared and tries to sign all inputs that belong to the wallet. Lnd must be
     the last signer of the transaction. That means, if there are any unsigned
@@ -173,6 +237,9 @@ message ListUnspentRequest {
 
     // The maximum number of confirmations to be included.
     int32 max_confs = 2;
+
+    // An optional filter to only include outputs belonging to an account.
+    string account = 3;
 }
 
 message ListUnspentResponse {
@@ -189,6 +256,10 @@ message LeaseOutputRequest {
 
     // The identifying outpoint of the output being leased.
     lnrpc.OutPoint outpoint = 2;
+
+    // The time in seconds before the lock expires. If set to zero, the default
+    // lock duration is used.
+    uint64 expiration_seconds = 3;
 }
 
 message LeaseOutputResponse {
@@ -225,13 +296,161 @@ message KeyReq {
 }
 
 message AddrRequest {
-    // No fields, as we always give out a p2wkh address.
+    /*
+    The name of the account to retrieve the next address of. If empty, the
+    default wallet account is used.
+    */
+    string account = 1;
+
+    /*
+    The type of address to derive.
+    */
+    AddressType type = 2;
+
+    /*
+    Whether a change address should be derived.
+    */
+    bool change = 3;
 }
 message AddrResponse {
     /*
     The address encoded using a bech32 format.
     */
     string addr = 1;
+}
+
+enum AddressType {
+    UNKNOWN = 0;
+    WITNESS_PUBKEY_HASH = 1;
+    NESTED_WITNESS_PUBKEY_HASH = 2;
+    HYBRID_NESTED_WITNESS_PUBKEY_HASH = 3;
+}
+message Account {
+    // The name used to identify the account.
+    string name = 1;
+
+    /*
+    The type of addresses the account supports.
+    AddressType                       | External Branch | Internal Branch
+    ---------------------------------------------------------------------
+    WITNESS_PUBKEY_HASH               | P2WPKH          | P2WPKH
+    NESTED_WITNESS_PUBKEY_HASH        | NP2WPKH         | NP2WPKH
+    HYBRID_NESTED_WITNESS_PUBKEY_HASH | NP2WPKH         | P2WPKH
+    */
+    AddressType address_type = 2;
+
+    /*
+    The public key backing the account that all keys are derived from
+    represented as an extended key. This will always be empty for the default
+    imported account in which single public keys are imported into.
+    */
+    string extended_public_key = 3;
+
+    /*
+    The fingerprint of the root key from which the account public key was
+    derived from. This will always be zero for the default imported account in
+    which single public keys are imported into. The bytes are in big-endian
+    order.
+    */
+    bytes master_key_fingerprint = 4;
+
+    /*
+    The derivation path corresponding to the account public key. This will
+    always be empty for the default imported account in which single public keys
+    are imported into.
+    */
+    string derivation_path = 5;
+
+    /*
+    The number of keys derived from the external branch of the account public
+    key. This will always be zero for the default imported account in which
+    single public keys are imported into.
+    */
+    uint32 external_key_count = 6;
+
+    /*
+    The number of keys derived from the internal branch of the account public
+    key. This will always be zero for the default imported account in which
+    single public keys are imported into.
+    */
+    uint32 internal_key_count = 7;
+
+    // Whether the wallet stores private keys for the account.
+    bool watch_only = 8;
+}
+message ListAccountsRequest {
+    // An optional filter to only return accounts matching this name.
+    string name = 1;
+
+    // An optional filter to only return accounts matching this address type.
+    AddressType address_type = 2;
+}
+message ListAccountsResponse {
+    repeated Account accounts = 1;
+}
+
+message ImportAccountRequest {
+    // A name to identify the account with.
+    string name = 1;
+
+    /*
+    A public key that corresponds to a wallet account represented as an extended
+    key. It must conform to a derivation path of the form
+    m/purpose'/coin_type'/account'.
+    */
+    string extended_public_key = 2;
+
+    /*
+    The fingerprint of the root key (also known as the key with derivation path
+    m/) from which the account public key was derived from. This may be required
+    by some hardware wallets for proper identification and signing. The bytes
+    must be in big-endian order.
+    */
+    bytes master_key_fingerprint = 3;
+
+    /*
+    An address type is only required when the extended account public key has a
+    legacy version (xpub, tpub, etc.), such that the wallet cannot detect what
+    address scheme it belongs to.
+    */
+    AddressType address_type = 4;
+
+    /*
+    Whether a dry run should be attempted when importing the account. This
+    serves as a way to confirm whether the account is being imported correctly
+    by returning the first N addresses for the external and internal branches of
+    the account. If these addresses match as expected, then it should be safe to
+    import the account as is.
+    */
+    bool dry_run = 5;
+}
+message ImportAccountResponse {
+    // The details of the imported account.
+    Account account = 1;
+
+    /*
+    The first N addresses that belong to the external branch of the account.
+    The external branch is typically used for external non-change addresses.
+    These are only returned if a dry run was specified within the request.
+    */
+    repeated string dry_run_external_addrs = 2;
+
+    /*
+    The first N addresses that belong to the internal branch of the account.
+    The internal branch is typically used for change addresses. These are only
+    returned if a dry run was specified within the request.
+    */
+    repeated string dry_run_internal_addrs = 3;
+}
+
+message ImportPublicKeyRequest {
+    // A compressed public key represented as raw bytes.
+    bytes public_key = 1;
+
+    // The type of address that will be generated from the public key.
+    AddressType address_type = 2;
+}
+message ImportPublicKeyResponse {
 }
 
 message Transaction {
@@ -400,11 +619,12 @@ message PendingSweep {
     uint32 amount_sat = 3;
 
     /*
-    The fee rate we'll use to sweep the output. The fee rate is only determined
-    once a sweeping transaction for the output is created, so it's possible for
-    this to be 0 before this.
+    Deprecated, use sat_per_vbyte.
+    The fee rate we'll use to sweep the output, expressed in sat/vbyte. The fee
+    rate is only determined once a sweeping transaction for the output is
+    created, so it's possible for this to be 0 before this.
     */
-    uint32 sat_per_byte = 4;
+    uint32 sat_per_byte = 4 [deprecated = true];
 
     // The number of broadcast attempts we've made to sweep the output.
     uint32 broadcast_attempts = 5;
@@ -418,8 +638,19 @@ message PendingSweep {
     // The requested confirmation target for this output.
     uint32 requested_conf_target = 8;
 
-    // The requested fee rate, expressed in sat/byte, for this output.
-    uint32 requested_sat_per_byte = 9;
+    // Deprecated, use requested_sat_per_vbyte.
+    // The requested fee rate, expressed in sat/vbyte, for this output.
+    uint32 requested_sat_per_byte = 9 [deprecated = true];
+
+    /*
+    The fee rate we'll use to sweep the output, expressed in sat/vbyte. The fee
+    rate is only determined once a sweeping transaction for the output is
+    created, so it's possible for this to be 0 before this.
+    */
+    uint64 sat_per_vbyte = 10;
+
+    // The requested fee rate, expressed in sat/vbyte, for this output.
+    uint64 requested_sat_per_vbyte = 11;
 
     /*
     Whether this input must be force-swept. This means that it is swept even
@@ -446,16 +677,23 @@ message BumpFeeRequest {
     uint32 target_conf = 2;
 
     /*
-    The fee rate, expressed in sat/byte, that should be used to spend the input
+    Deprecated, use sat_per_vbyte.
+    The fee rate, expressed in sat/vbyte, that should be used to spend the input
     with.
     */
-    uint32 sat_per_byte = 3;
+    uint32 sat_per_byte = 3 [deprecated = true];
 
     /*
     Whether this input must be force-swept. This means that it is swept even
     if it has a negative yield.
     */
     bool force = 4;
+
+    /*
+    The fee rate, expressed in sat/vbyte, that should be used to spend the input
+    with.
+    */
+    uint64 sat_per_vbyte = 5;
 }
 
 message BumpFeeResponse {
@@ -530,8 +768,21 @@ message FundPsbtRequest {
         The fee rate, expressed in sat/vbyte, that should be used to spend the
         input with.
         */
-        uint32 sat_per_vbyte = 4;
+        uint64 sat_per_vbyte = 4;
     }
+
+    /*
+    The name of the account to fund the PSBT with. If empty, the default wallet
+    account is used.
+    */
+    string account = 5;
+
+    // The minimum number of confirmations each one of your outputs used for
+    // the transaction must satisfy.
+    int32 min_confs = 6;
+
+    // Whether unconfirmed outputs should be used as inputs for the transaction.
+    bool spend_unconfirmed = 7;
 }
 message FundPsbtResponse {
     /*
@@ -584,6 +835,19 @@ message UtxoLease {
     uint64 expiration = 3;
 }
 
+message SignPsbtRequest {
+    /*
+    The PSBT that should be signed. The PSBT must contain all required inputs,
+    outputs, UTXO data and custom fields required to identify the signing key.
+    */
+    bytes funded_psbt = 1;
+}
+
+message SignPsbtResponse {
+    // The signed transaction in PSBT format.
+    bytes signed_psbt = 1;
+}
+
 message FinalizePsbtRequest {
     /*
     A PSBT that should be signed and finalized. The PSBT must contain all
@@ -591,6 +855,12 @@ message FinalizePsbtRequest {
     signers.
     */
     bytes funded_psbt = 1;
+
+    /*
+    The name of the account to finalize the PSBT with. If empty, the default
+    wallet account is used.
+    */
+    string account = 5;
 }
 message FinalizePsbtResponse {
     // The fully signed and finalized transaction in PSBT format.
@@ -598,4 +868,12 @@ message FinalizePsbtResponse {
 
     // The fully signed and finalized transaction in the raw wire format.
     bytes raw_final_tx = 2;
+}
+
+message ListLeasesRequest {
+}
+
+message ListLeasesResponse {
+    // The list of currently leased utxos.
+    repeated UtxoLease locked_utxos = 1;
 }

--- a/proto/walletunlocker.proto
+++ b/proto/walletunlocker.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-import "rpc.proto";
+import "lightning.proto";
 
 package lnrpc;
 
@@ -149,6 +149,42 @@ message InitWalletRequest {
     RPC as otherwise all access to the daemon will be lost!
     */
     bool stateless_init = 6;
+
+    /*
+    extended_master_key is an alternative to specifying cipher_seed_mnemonic and
+    aezeed_passphrase. Instead of deriving the master root key from the entropy
+    of an aezeed cipher seed, the given extended master root key is used
+    directly as the wallet's master key. This allows users to import/use a
+    master key from another wallet. When doing so, lnd still uses its default
+    SegWit only (BIP49/84) derivation paths and funds from custom/non-default
+    derivation paths will not automatically appear in the on-chain wallet. Using
+    an 'xprv' instead of an aezeed also has the disadvantage that the wallet's
+    birthday is not known as that is an information that's only encoded in the
+    aezeed, not the xprv. Therefore a birthday needs to be specified in
+    extended_master_key_birthday_timestamp or a "safe" default value will be
+    used.
+    */
+    string extended_master_key = 7;
+
+    /*
+    extended_master_key_birthday_timestamp is the optional unix timestamp in
+    seconds to use as the wallet's birthday when using an extended master key
+    to restore the wallet. lnd will only start scanning for funds in blocks that
+    are after the birthday which can speed up the process significantly. If the
+    birthday is not known, this should be left at its default value of 0 in
+    which case lnd will start scanning from the first SegWit block (481824 on
+    mainnet).
+    */
+    uint64 extended_master_key_birthday_timestamp = 8;
+
+    /*
+    watch_only is the third option of initializing a wallet: by importing
+    account xpubs only and therefore creating a watch-only wallet that does not
+    contain any private keys. That means the wallet won't be able to sign for
+    any of the keys and _needs_ to be run with a remote signer that has the
+    corresponding private keys and can serve signing RPC requests.
+    */
+    WatchOnly watch_only = 9;
 }
 message InitWalletResponse {
     /*
@@ -159,6 +195,63 @@ message InitWalletResponse {
     daemon, together with other macaroon files.
     */
     bytes admin_macaroon = 1;
+}
+
+message WatchOnly {
+    /*
+    The unix timestamp in seconds of when the master key was created. lnd will
+    only start scanning for funds in blocks that are after the birthday which
+    can speed up the process significantly. If the birthday is not known, this
+    should be left at its default value of 0 in which case lnd will start
+    scanning from the first SegWit block (481824 on mainnet).
+    */
+    uint64 master_key_birthday_timestamp = 1;
+
+    /*
+    The fingerprint of the root key (also known as the key with derivation path
+    m/) from which the account public keys were derived from. This may be
+    required by some hardware wallets for proper identification and signing. The
+    bytes must be in big-endian order.
+    */
+    bytes master_key_fingerprint = 2;
+
+    /*
+    The list of accounts to import. There _must_ be an account for all of lnd's
+    main key scopes: BIP49/BIP84 (m/49'/0'/0', m/84'/0'/0', note that the
+    coin type is always 0, even for testnet/regtest) and lnd's internal key
+    scope (m/1017'/<coin_type>'/<account>'), where account is the key family as
+    defined in `keychain/derivation.go` (currently indices 0 to 9).
+     */
+    repeated WatchOnlyAccount accounts = 3;
+}
+
+message WatchOnlyAccount {
+    /*
+    Purpose is the first number in the derivation path, must be either 49, 84
+    or 1017.
+    */
+    uint32 purpose = 1;
+
+    /*
+    Coin type is the second number in the derivation path, this is _always_ 0
+    for purposes 49 and 84. It only needs to be set to 1 for purpose 1017 on
+    testnet or regtest.
+    */
+    uint32 coin_type = 2;
+
+    /*
+    Account is the third number in the derivation path. For purposes 49 and 84
+    at least the default account (index 0) needs to be created but optional
+    additional accounts are allowed. For purpose 1017 there needs to be exactly
+    one account for each of the key families defined in `keychain/derivation.go`
+    (currently indices 0 to 9)
+    */
+    uint32 account = 3;
+
+    /*
+    The extended public key at depth 3 for the given account.
+    */
+    string xpub = 4;
 }
 
 message UnlockWalletRequest {

--- a/src/grpc/lightning.ts
+++ b/src/grpc/lightning.ts
@@ -87,7 +87,7 @@ export async function loadLightning(
 
   // LND
   const credentials = loadCredentials()
-  const lnrpcDescriptor = grpc.load('proto/rpc.proto')
+  const lnrpcDescriptor = grpc.load('proto/lightning.proto')
   const lnrpc: any = lnrpcDescriptor.lnrpc
   lightningClient = new lnrpc.Lightning(
     LND_IP + ':' + config.lnd_port,
@@ -935,7 +935,7 @@ function ascii_to_hexa(str) {
 //     return lightningClient
 //   } else {
 //   	var credentials = loadCredentials()
-//     const packageDefinition = await protoLoader.load("rpc.proto", {})
+//     const packageDefinition = await protoLoader.load("lightning.proto", {})
 //     const lnrpcDescriptor = grpc.loadPackageDefinition(packageDefinition);
 //     var { lnrpc } = lnrpcDescriptor;
 //     lightningClient = new lnrpc.Lightning(LND_IP + ':' + config.lnd_port, credentials);

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -186,7 +186,7 @@ export function getProxyRootPubkey(): Promise<string> {
     }
     // normal client, to get pubkey of LND
     const credentials = Lightning.loadCredentials()
-    const lnrpcDescriptor = grpc.load('proto/rpc.proto')
+    const lnrpcDescriptor = grpc.load('proto/lightning.proto')
     const lnrpc: any = lnrpcDescriptor.lnrpc
     const lc = new lnrpc.Lightning(LND_IP + ':' + config.lnd_port, credentials)
     lc.getInfo({}, function (err, response) {
@@ -204,7 +204,7 @@ function getProxyLNDBalance(): Promise<number> {
   return new Promise((resolve, reject) => {
     // normal client, to get pubkey of LND
     const credentials = Lightning.loadCredentials()
-    const lnrpcDescriptor = grpc.load('proto/rpc.proto')
+    const lnrpcDescriptor = grpc.load('proto/lightning.proto')
     const lnrpc: any = lnrpcDescriptor.lnrpc
     const lc = new lnrpc.Lightning(LND_IP + ':' + config.lnd_port, credentials)
     lc.channelBalance({}, function (err, response) {


### PR DESCRIPTION
in #362 i once got an error that a certain field of a rpc response didn't exist when it should have, later i found out these proto files where outdated and the field was missing.

to prevent these types bugs in the future this workflow runs every month, it pulls the proto files from the lnd repository and updates them.

```test -e proto/`basename {}` &&``` ensures only proto files that already exist are updated

greenlight stuff is untouched and rpc.proto had to be renamed to lightning.proto because lnd did