### PR TITLE
set fail-fast to false in integration_test.yml 

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -8,6 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-18.04 
     strategy:
+      fail-fast: false
       matrix:
         test-name: ['boostPayment', 'botCreation', 'chatPayment', 'cleanup', 'clearAllChats', 'clearAllContacts', 'contacts', 'images', 'latestTest', 'lsats', 'paidMeet', 'paidTribeImages', 'queryRoutes', 'self', 'sphinxPeople', 'streamPayment', 'tribe', 'tribe3Escrow', 'tribe3Messages', 'tribe3Private', 'tribe3Profile', 'tribeEdit', 'tribeImages', 'messageLength', 'transportToken', 'pinnedMsg', 'hmac', 'socketIO']
     steps:


### PR DESCRIPTION
set fail-fast to false in integration_test.yml to not cancel other tests if one fails

found this in some other workflow and thought this would be handy here too