### PR TITLE
removed bcrypt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get -y install git
 
 RUN rm ./package-lock.json
 
-RUN npm install bcrypt
 RUN npm install
 
 RUN cp /relay/config/app.json /relay/dist/config/app.json


### PR DESCRIPTION
checking to see if the integration tests will fail if we remove bcrypt

if it works it would close https://github.com/stakwork/sphinx-relay/issues/420

probably more checking may need to be done tho