### PR TITLE
fix: lower limit amount for /feeds

### DIFF
--- a/src/controllers/getFeeds.ts
+++ b/src/controllers/getFeeds.ts
@@ -11,9 +11,11 @@ export async function getFeeds(req: Req, res: Response) {
   const tenant: number = req.owner.id
   const config = loadConfig()
   try {
+    //TODO: compress the request
+    // limit set to 90 because request size was getting to large
     const actions = (await models.ActionHistory.findAll({
       where: { tenant },
-      limit: 500,
+      limit: 90,
       order: [['updatedAt', 'DESC']],
     })) as ActionHistoryRecord[]
     const parsedActions = feedsHelper.parseActionHistory(actions)


### PR DESCRIPTION
This is because when we were pulling the action history there is a large size but express is throwing an error when the request size is too large. So I added a todo to compress the size of the request so we can fit more data into it