### PR TITLE
test: enable non legacy socketio test

### DIFF
--- a/src/tests/controllers/socketIO.test.ts
+++ b/src/tests/controllers/socketIO.test.ts
@@ -34,7 +34,7 @@ let io: any = null
 var responseArray: any[] = []
 
 test.serial('test-09-socketIO', async (t: ExecutionContext<Context>) => {
-  //await testSocketIO(t, false)
+  await testSocketIO(t, false)
 
   await testSocketIO(t, true)
 })


### PR DESCRIPTION
seems like we were only testing the legacy socketIO module, I'm just enabling this test