### PR TITLE
fix bug introduced by #686: add dist folder after updating generated types

### DIFF
--- a/.github/workflows/lint_format_and_build.yml
+++ b/.github/workflows/lint_format_and_build.yml
@@ -30,6 +30,6 @@ jobs:
           git push
           bash grpc_gen_types.sh
           npm run build
-          git add src/grpc/types src/grpc/proto.ts
+          git add src/grpc/types src/grpc/proto.ts dist --force
           git commit -m 'Update proto files and types' || echo -n
           git push


### PR DESCRIPTION
dist needs to be added after updating types, the types also contains enums which have runtime values
most of the files are .d.ts, but a few are .ts and compile to js, like https://github.com/stakwork/sphinx-relay/blob/master/src/grpc/types/lnrpc_proxy/FeatureBit.ts, (note `export const`)